### PR TITLE
Support packit for Pull Request tests and sync to Fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,7 +185,6 @@ var/
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,27 @@
+specfile_path: python-deprecated.spec
+synced_files:
+  - python-deprecated.spec
+  - .packit.yaml
+upstream_project_name: Deprecated
+downstream_package_name: python-deprecated
+create_pr: false
+jobs:
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branch: master
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branch: f30
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branch: f29
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-30-x86_64
+    - fedora-29-x86_64
+    - fedora-rawhide-x86_64

--- a/python-deprecated.spec
+++ b/python-deprecated.spec
@@ -1,0 +1,49 @@
+%global srcname Deprecated
+%global pkgname deprecated
+
+Name:           python-%{pkgname}
+Version:        1.2.6
+Release:        2%{?dist}
+Summary:        Python decorator to deprecate old python classes, functions or methods
+License:        MIT
+URL:            https://github.com/tantale/%{pkgname}
+Source0:        https://files.pythonhosted.org/packages/source/D/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+
+%description
+Python @deprecated decorator to deprecate old python classes,
+functions or methods.
+
+%package -n python3-%{pkgname}
+Summary:        %{summary}
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+%{?python_provide:%python_provide python3-%{pkgname}}
+
+%description -n python3-%{pkgname}
+Python @deprecated decorator to deprecate old python classes,
+functions or methods.
+
+%prep
+%autosetup -n %{srcname}-%{version}
+rm -rf %{pkgname}.egg-info
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+%files -n python3-%{pkgname}
+%license LICENSE.rst
+%doc README.md
+%{python3_sitelib}/%{pkgname}/
+%{python3_sitelib}/%{srcname}-%{version}-*.egg-info/
+
+
+%changelog
+* Fri Jul 26 2019 Petr Hracek <phracek@redhat.com> - 1.2.6-2
+- Fix python3_sitelib issue
+
+* Fri Jul 26 2019 Petr Hracek <phracek@redhat.com> - 1.2.6-1
+- Initial package


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>
This issue fixes #11 
It contains `.packit.yaml` file and `python-deprecated.spec` file for distribution into Fedora.

Once it is merged in upstream you should allow packit-as-a-service into your repository
https://github.com/marketplace/packit-as-a-service

Once the Pull Request is created, `Packit-as-a-service` checks if it is buildable in Fedora environment and shows you how to test it.
Another feature is, that if you release a new version into PyPi, `Packit-as-a-Service` automatically push it into Fedora ecosystem.

For more information https://packit.dev/