### PR TITLE
Refer to a function caller not wrapt/wrappers.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,12 @@ v1.2.7 (unreleased)
 
 Bug fix release
 
+Fix
+---
+
+- Warning displays the correct filename and line number when decorating a function if wrapt
+  does not have the compiled c extension.
+
 Other
 -----
 

--- a/deprecated/classic.py
+++ b/deprecated/classic.py
@@ -12,6 +12,16 @@ import warnings
 
 import wrapt
 
+try:
+    # If the c extension for wrapt was compiled and wrapt/_wrappers.pyd exists, then the
+    # stack level that should be passed to warnings.warn should be 2. However, if using
+    # a pure python wrapt, a extra stacklevel is required.
+    import wrapt._wrappers
+    _stacklevel = 2
+except ImportError:
+    _stacklevel = 3
+
+
 string_types = (type(b''), type(u''))
 
 
@@ -227,7 +237,7 @@ def deprecated(*args, **kwargs):
                 msg = adapter.get_deprecated_msg(wrapped_, instance_)
                 with warnings.catch_warnings():
                     warnings.simplefilter(action, category)
-                    warnings.warn(msg, category=category, stacklevel=2)
+                    warnings.warn(msg, category=category, stacklevel=_stacklevel)
                 return wrapped_(*args_, **kwargs_)
 
             return wrapper_function(wrapped)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -135,6 +135,7 @@ def test_classic_deprecated_function__warns(classic_deprecated_function):
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated function (or staticmethod)" in str(warn.message)
+    assert warn.filename == __file__, 'Incorrect warning stackLevel'
 
 
 # noinspection PyShadowingNames
@@ -146,6 +147,7 @@ def test_classic_deprecated_class__warns(classic_deprecated_class):
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated class" in str(warn.message)
+    assert warn.filename == __file__, 'Incorrect warning stackLevel'
 
 
 # noinspection PyShadowingNames
@@ -158,6 +160,7 @@ def test_classic_deprecated_method__warns(classic_deprecated_method):
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated method" in str(warn.message)
+    assert warn.filename == __file__, 'Incorrect warning stackLevel'
 
 
 # noinspection PyShadowingNames
@@ -169,6 +172,7 @@ def test_classic_deprecated_static_method__warns(classic_deprecated_static_metho
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated function (or staticmethod)" in str(warn.message)
+    assert warn.filename == __file__, 'Incorrect warning stackLevel'
 
 
 # noinspection PyShadowingNames
@@ -181,6 +185,7 @@ def test_classic_deprecated_class_method__warns(classic_deprecated_class_method)
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated function (or staticmethod)" in str(warn.message)
+    assert warn.filename == __file__, 'Incorrect warning stackLevel'
 
 
 def test_should_raise_type_error():


### PR DESCRIPTION
When using `@deprecated.deprecated` on a module function, the raised warning reports the problem in "wrapt\wrappers.py" instead of the file that called the decorated function.

test.py:
```python
from deprecated import deprecated
@deprecated
def foo1():
    pass

class Test(object):
    @deprecated
    def foo2(self):
        pass

if __name__ == '__main__':
    foo1()

    t = Test()
    t.foo2()
```
When running `python test.py` with the un-patched deprecated module results in:
```
C:\Program Files\Python37\lib\site-packages\wrapt\wrappers.py:564: DeprecationWarning: Call to deprecated function (or staticmethod) foo1.
  args, kwargs)
C:\Program Files\Python37\lib\site-packages\wrapt\wrappers.py:603: DeprecationWarning: Call to deprecated method foo2.
  args, kwargs)
```

This makes it hard to track down the code that is calling the deprecated method.

With the patch:
```
test.py:12: DeprecationWarning: Call to deprecated function (or staticmethod) foo1.
  foo1()
test.py:15: DeprecationWarning: Call to deprecated method foo2.
  t.foo2()
```

This makes it easy to find and fix the call to a deprecated method and I assume is the desired behavior.
