### PR TITLE
Travis CI: Drop Python 3.4 and add Py 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: python
 python:
-  # Python **2.6** and **3.3** are no more supported
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.8-dev"   # 3.8 development branch
-  # - "pypy"    # some unit tests fail
+  - "3.9-dev"   # 3.8 development branch
+  # - "pypy3"    # some unit tests fail
 install:
-  - pip install tox-travis
-  - pip install coveralls
+  - pip install coveralls tox-travis
 script:
   tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
 jobs:
   allow_failures:
     - python: "3.9-dev"
-    - python: "pypy3"
 install:
   - pip install coveralls tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"   # 3.8 development branch
-  # - "pypy3"    # some unit tests fail
+  - "3.9-dev"  # 3.9 development branch
+  - "pypy3"    # some unit tests fail
+jobs:
+  allow_failures:
+    - python: "3.9-dev"
+    - python: "pypy3"
 install:
   - pip install coveralls tox-travis
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -12,18 +12,18 @@
 # - /usr/local/bin/pypy -> /opt/pypy2.7-v7.3.0-osx64/bin/pypy
 # - /usr/local/bin/pypy3 -> /opt/pypy3.6-v7.3.0-osx64/bin/pypy3
 envlist =
-    py{27,34,35,36,37,38}-wrapt{1.10,1.11,1.12}
+    py{27,35,36,37,38,39}-wrapt{1.10,1.11,1.12}
     pypy, pypy3
     docs
 
 [testenv]
 commands = pytest --cov-report term-missing --cov=deprecated tests/
 deps =
-    py27,py34,py35: pip >= 9.0.3, < 19.2
-    py27,py34: PyTest < 5
+    py27,py35: pip >= 9.0.3, < 19.2
+    py27: PyTest < 5
     py35,py36,py37,py38,pypy,pypy3: PyTest
-    py27,py34: PyTest-Cov < 2.6
-    py35,py36,py37,py38,pypy,pypy3: PyTest-Cov
+    py27: PyTest-Cov < 2.6
+    py35,py36,py37,py38,py39,pypy,pypy3: PyTest-Cov
     wrapt1.10: wrapt ~= 1.10.0
     wrapt1.11: wrapt ~= 1.11.0
     wrapt1.12: wrapt ~= 1.12.0

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@
 # and then run "tox" from this directory.
 
 [tox]
-# py32 not supported by tox and pytest
 # PyPy configuration (on Linux/OSX):
 # - /usr/local/bin/pypy -> /opt/pypy2.7-v7.3.0-osx64/bin/pypy
 # - /usr/local/bin/pypy3 -> /opt/pypy3.6-v7.3.0-osx64/bin/pypy3


### PR DESCRIPTION
Pip is on it way to getting a real dependency resolver so it is better to provide it with multiple dependencies at once.

Travis CI will now successfully tests on all currently supported versions of CPython and pypy3.  It also runs Python 3.9-dev in [`allow_failures`](https://docs.travis-ci.com/user/build-matrix/#rows-that-are-allowed-to-fail) mode until the current failure can be fixed.

Describe what this patch does to fix the issue.

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with `pytest`
* add documentation to the relevant docstrings or pages
* add `versionadded` or `versionchanged` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
