### PR TITLE
Fix #15: ``@deprecated`` respects global warning filters with actions other than "ignore" and "always" on Python 3

### DIFF
--- a/deprecated/classic.py
+++ b/deprecated/classic.py
@@ -161,9 +161,11 @@ class ClassicAdapter(wrapt.AdapterFactory):
 
             def wrapped_cls(cls, *args, **kwargs):
                 msg = self.get_deprecated_msg(wrapped, None)
-                with warnings.catch_warnings():
-                    if self.action:
+                if self.action:
+                    with warnings.catch_warnings():
                         warnings.simplefilter(self.action, self.category)
+                        warnings.warn(msg, category=self.category, stacklevel=_class_stacklevel)
+                else:
                     warnings.warn(msg, category=self.category, stacklevel=_class_stacklevel)
                 if old_new1 is object.__new__:
                     return old_new1(cls)
@@ -274,9 +276,11 @@ def deprecated(*args, **kwargs):
             @wrapt.decorator(adapter=adapter)
             def wrapper_function(wrapped_, instance_, args_, kwargs_):
                 msg = adapter.get_deprecated_msg(wrapped_, instance_)
-                with warnings.catch_warnings():
-                    if action:
+                if action:
+                    with warnings.catch_warnings():
                         warnings.simplefilter(action, category)
+                        warnings.warn(msg, category=category, stacklevel=_routine_stacklevel)
+                else:
                     warnings.warn(msg, category=category, stacklevel=_routine_stacklevel)
                 return wrapped_(*args_, **kwargs_)
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -248,8 +248,9 @@ def test_respect_global_filter():
     def fun():
         print("fun")
 
-    warnings.simplefilter("ignore", category=DeprecationWarning)
+    warnings.simplefilter("once", category=DeprecationWarning)
 
     with warnings.catch_warnings(record=True) as warns:
         fun()
-    assert len(warns) == 0
+        fun()
+    assert len(warns) == 1

--- a/tests/test_deprecated_class.py
+++ b/tests/test_deprecated_class.py
@@ -106,6 +106,19 @@ def test_class_deprecation_using_deprecated_decorator():
     assert issubclass(MySubClass, MyBaseClass)
 
 
+def test_class_respect_global_filter():
+    @deprecated.classic.deprecated
+    class MyBaseClass(object):
+        pass
+
+    with warnings.catch_warnings(record=True) as warns:
+        warnings.simplefilter("once")
+        obj = MyBaseClass()
+        obj = MyBaseClass()
+
+    assert len(warns) == 1
+
+
 def test_subclass_deprecation_using_deprecated_decorator():
     @deprecated.classic.deprecated
     class MyBaseClass(object):


### PR DESCRIPTION
With filter actions such as "default", "once", and "module", Python keeps track of what warnings have fired in warning registries. When entering the `warnings.catch_warnings()` context manager in Python 3, all warning registries get cleared. `@deprecated` enters `warnings.catch_warnings()` every time it issues a warning. This makes actions like "default", "once", and "module" appear to behave like "always" since the warning registries are always empty when `@deprecated` fires its warning.

Run the following with `python3` to see the behavior I'm talking about:
```python
from deprecated import deprecated
import warnings

warnings.simplefilter(action='once', category=DeprecationWarning)

@deprecated(reason='this message should show up once')
def a():
    return

a()
a()
a()
```