### PR TITLE
Update expected class method deprecation msgs in tests for py3.9

### DIFF
--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 import warnings
 
 import pytest
@@ -184,7 +185,10 @@ def test_classic_deprecated_class_method__warns(classic_deprecated_class_method)
     assert len(warns) == 1
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
-    assert "deprecated function (or staticmethod)" in str(warn.message)
+    if sys.version_info >= (3, 9):
+        assert "deprecated class method" in str(warn.message)
+    else:
+        assert "deprecated function (or staticmethod)" in str(warn.message)
     assert warn.filename == __file__, 'Incorrect warning stackLevel'
 
 

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -334,7 +334,10 @@ def test_sphinx_deprecated_class_method__warns(sphinx_deprecated_class_method):
     assert len(warns) == 1
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
-    assert "deprecated function (or staticmethod)" in str(warn.message)
+    if sys.version_info >= (3, 9):
+        assert "deprecated class method" in str(warn.message)
+    else:
+        assert "deprecated function (or staticmethod)" in str(warn.message)
 
 
 def test_should_raise_type_error():


### PR DESCRIPTION
Python 3.9 has fixed @classmethod combining with other decorators,
making deprecated correctly report 'class method' (instead of function
or static method).  Update the tests to account for that.

Fixes #29