### PR TITLE
.packit.yml update

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,33 +1,17 @@
-specfile_path: python-deprecated.spec
 synced_files:
   - python-deprecated.spec
   - .packit.yml
-upstream_project_name: Deprecated
+upstream_package_name: Deprecated
 upstream_tag_template: v{version}
 downstream_package_name: python-deprecated
-create_pr: false
 jobs:
-  - job: propose_downstream
-    trigger: release
-    metadata:
-      dist-git-branch: master
-  - job: propose_downstream
-    trigger: release
-    metadata:
-      dist-git-branch: fedora-all
-  - job: propose_downstream
-    trigger: release
-    metadata:
-      dist-git-branch: f30
-  - job: propose_downstream
-    trigger: release
-    metadata:
-      dist-git-branch: f29
-  - job: copr_build
-    trigger: pull_request
-    metadata:
-      targets:
-        - fedora-all
-        - fedora-30-x86_64
-        - fedora-29-x86_64
-        - fedora-rawhide-x86_64
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branches:
+    - fedora-all
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-all

--- a/python-deprecated.spec
+++ b/python-deprecated.spec
@@ -7,7 +7,7 @@ Release:        2%{?dist}
 Summary:        Python decorator to deprecate old python classes, functions or methods
 License:        MIT
 URL:            https://github.com/tantale/%{pkgname}
-Source0:        https://files.pythonhosted.org/packages/source/D/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 %description
@@ -38,7 +38,7 @@ rm -rf %{pkgname}.egg-info
 %license LICENSE.rst
 %doc README.md
 %{python3_sitelib}/%{pkgname}/
-%{python3_sitelib}/%{srcname}-%{version}-*.egg-info/
+%{python3_sitelib}/%{srcname}-*.egg-info/
 
 
 %changelog


### PR DESCRIPTION
- Removed `specfile_path` since the [default value](https://packit.dev/docs/configuration/#specfile_path) is fine.
- `upstream_project_name` renamed to [`upstream_package_name`](https://packit.dev/docs/configuration/#upstream_package_name)
- `create_pr: false` removed. We used to need this because of some problem with Fedora Pagure (git forge) API, but it's no longer needed.
- Merged `propose_downstream` jobs since [`fedora-all` alias](https://packit.dev/docs/configuration/#supported-jobs) now works OK.