### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     
 allow_failures:
     - python: "3.9-dev"
-    - python" "pypy"
+    - python: "pypy"
 install:
   - pip install coveralls tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,16 @@ python:
   - "3.9-dev"  # 3.9 development branch
   - "pypy"
   - "pypy3"
+exclude:
+ jobs:
+  - python: 2.7
+    arch: ppc64le
+  - python: pypy
+    arch: ppc64le
+  - python: pypy3
+    arch: ppc64le
+  - python: pypy
+    arch: amd64
 jobs:
   allow_failures:
     - python: "3.9-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ python:
 jobs:
  exclude:
   - arch: ppc64le
-    python: 2.7
+    python: "2.7"
   - arch: ppc64le
-    arch: pypy
+    arch: "pypy"
   - arch: ppc64le 
-    python: pypy3
+    python: "pypy3"
   - arch: amd64
-    python: pypy
+    python: "pypy"
     
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ python:
   - "3.9-dev"  # 3.9 development branch
   - "pypy"
   - "pypy3"
-exclude:
- jobs:
+jobs:
+ exclude:
   - arch: ppc64le
     python: 2.7
   - arch: ppc64le
@@ -21,6 +21,7 @@ exclude:
     python: pypy3
   - arch: amd64
     python: pypy
+    
 jobs:
   allow_failures:
     - python: "3.9-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ jobs:
   - arch: amd64
     python: "pypy"
     
-jobs:
-  allow_failures:
+allow_failures:
     - python: "3.9-dev"
 install:
   - pip install coveralls tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
     
 allow_failures:
     - python: "3.9-dev"
+    - python" "pypy"
 install:
   - pip install coveralls tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ python:
   - "3.9-dev"  # 3.9 development branch
   - "pypy"
   - "pypy3"
-jobs:
- exclude:
-  - python: 2.7
-    arch: ppc64le
-  - python: pypy
-    arch: ppc64le
-  - python: pypy3
-    arch: ppc64le
-  - python: pypy
-    arch: amd64
+exclude:
+ jobs:
+  - arch: ppc64le
+    python: 2.7
+  - arch: ppc64le
+    arch: pypy
+  - arch: ppc64le 
+    python: pypy3
+  - arch: amd64
+    python: pypy
 jobs:
   allow_failures:
     - python: "3.9-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
   - arch: ppc64le
     python: "2.7"
   - arch: ppc64le
-    arch: "pypy"
+    python: "pypy"
   - arch: ppc64le 
     python: "pypy3"
   - arch: amd64
@@ -24,7 +24,7 @@ jobs:
     
 allow_failures:
     - python: "3.9-dev"
-    - python: "pypy"
+    
 install:
   - pip install coveralls tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ python:
   - "3.9-dev"  # 3.9 development branch
   - "pypy"
   - "pypy3"
-exclude:
- jobs:
+jobs:
+ exclude:
   - python: 2.7
     arch: ppc64le
   - python: pypy


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/deprecated

Please let me know if you need any further details.

Thank You !!