### PR TITLE
Set the Release tag to 1 in the spec-file

### DIFF
--- a/python-deprecated.spec
+++ b/python-deprecated.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pkgname}
 Version:        1.2.13
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        Python decorator to deprecate old python classes, functions or methods
 License:        MIT
 URL:            https://github.com/tantale/%{pkgname}


### PR DESCRIPTION
As per the [Fedora Packaging Guidelines], the Release tag should be reset
to 1 whenever the Version tag is changed.

This means that the Release tag should always stay 1 in this repo.

This change will help new versions to be correctly be proposed to
Fedora Linux by Packit. Currently the Release tag needs to be fixed
before accepting the new version.

[Fedora Packaging Guidelines]: https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_simple_versioning

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

