### PR TITLE
Use upload_dir in setup.cfg to fix warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,4 @@ source-dir = docs/source
 build-dir = dist/docs
 
 [upload_docs]
-upload-dir = dist/docs/html
+upload_dir = dist/docs/html


### PR DESCRIPTION
Fix the following setuptools warning:

    /usr/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'upload-dir' will not be supported in future versions. Please use the underscore name 'upload_dir' instead