### PR TITLE
Fix #49: Pin wrapt package version to <1.13

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,10 @@ v1.2.14 (unreleased)
 
 Bug fix release
 
+Fix
+---
+
+- Fix #49: Pin wrapt package version to <1.13
 
 v1.2.13 (2021-09-05)
 ====================

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ setup(
     long_description_content_type="text/x-rst",
     keywords='deprecate,deprecated,deprecation,warning,warn,decorator',
     packages=['deprecated'],
-    install_requires=['wrapt < 2, >= 1.10'],
+    install_requires=['wrapt < 1.13, >= 1.10'],
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
I was not able to come up with an easy way to add a test for that change... Sorry about that.