### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,13 +33,13 @@ jobs:
         run: |
           pytest tests/
 
-  pytest-py36-py39:
+  pytest-py36-py310:
     runs-on: ${{ matrix.platform }}
 
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        # 'Programming Language :: Python :: 3.10',  # scheduled on 2021-10-04
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     extras_require={


### PR DESCRIPTION
# Describe what this patch does to fix the issue.

Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Add support by adding the Trove classifier and testing on GitHub Actions.


<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with `pytest`
* add documentation to the relevant docstrings or pages
* add `versionadded` or `versionchanged` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
