### PR TITLE
support for deprecated parameters

### DIFF
--- a/deprecated/param.py
+++ b/deprecated/param.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+"""
+Classic deprecation warning for parameters
+==========================================
+
+Classic ``@deprecated_param`` decorator to deprecate old keyword arguments.
+
+.. _The Warnings Filter: https://docs.python.org/3/library/warnings.html#the-warnings-filter
+"""
+import functools
+import inspect
+import platform
+import warnings
+
+import wrapt
+
+try:
+    # If the C extension for wrapt was compiled and wrapt/_wrappers.pyd exists, then the
+    # stack level that should be passed to warnings.warn should be 2. However, if using
+    # a pure python wrapt, a extra stacklevel is required.
+    import wrapt._wrappers
+
+    _routine_stacklevel = 2
+    _class_stacklevel = 2
+except ImportError:
+    _routine_stacklevel = 3
+    if platform.python_implementation() == "PyPy":
+        _class_stacklevel = 2
+    else:
+        _class_stacklevel = 3
+
+string_types = (type(b''), type(u''))
+
+
+class ClassicAdapterParam(wrapt.AdapterFactory):
+    """
+    Classic adapter is used to get the deprecation message according to the wrapped object type:
+    class, function, standard method, static method, or class method. This is the base class of the :class:`~deprecat.sphinx.SphinxAdapter` class
+    which is used to update the wrapped object docstring. You can also inherit this class to change the deprecation message.
+    Parameters
+    ----------
+    action: str
+        A warning filter used to specify the deprecation warning.
+        Can be one of "error", "ignore", "always", "default", "module", or "once".
+        If ``None`` or empty, the the global filtering mechanism is used.
+    deprecated_args: dict
+        Dictionary in the following format to deprecate `x` and `y`
+        deprecated_args = {'x': {'reason': 'some reason','version': '1.0'}, 'y': {'reason': 'another reason','version': '2.0'}}
+    category: class
+        The warning category to use for the deprecation warning.
+        By default, the category class is :class:`~DeprecationWarning`,
+        you can inherit this class to define your own deprecation warning category.
+    """
+
+    def __init__(self, action=None, deprecated_args=None, category=DeprecationWarning):
+        """
+        Construct a wrapper adapter.
+
+        :type  action: str
+        :param action:
+            A warning filter used to activate or not the deprecation warning.
+            Can be one of "error", "ignore", "always", "default", "module", or "once".
+            If ``None`` or empty, the the global filtering mechanism is used.
+            See: `The Warnings Filter`_ in the Python documentation.
+
+        :type  category: type
+        :param category:
+            The warning category to use for the deprecation warning.
+            By default, the category class is :class:`~DeprecationWarning`,
+            you can inherit this class to define your own deprecation warning category.
+        :type deprecated_args: dict
+        :param deprecated_args:
+            Dictionary in the following format to deprecate `x` and `y`
+            deprecated_args = {'x': {'reason': 'some reason','version': '1.0'}, 'y': {'reason': 'another reason','version': '2.0'}}
+        """
+        self.action = action
+        self.category = category
+        self.deprecated_args = deprecated_args
+        super(ClassicAdapterParam, self).__init__()
+
+    def get_deprecated_msg(self, wrapped, instance, kwargs):
+        """
+        Get the deprecation warning message for the user.
+
+        :param wrapped: Wrapped class or function.
+
+        :param instance: The object to which the wrapped function was bound when it was called.
+
+        :param kwargs: The keyword arguments that were passed to the wrapped function.
+
+        :return: The warning message.
+        """
+        if instance is None:
+            if inspect.isclass(wrapped):
+                fmt = "Call to deprecated class {name}."
+            else:
+                fmt = "Call to deprecated function (or staticmethod) {name}."
+        else:
+            if inspect.isclass(instance):
+                fmt = "Call to deprecated class method {name}."
+            else:
+                fmt = "Call to deprecated method {name}."
+
+        self.argstodeprecate = set(self.deprecated_args.keys()).intersection(kwargs)
+        if len(self.argstodeprecate)!=0:
+            warningargs={}
+            #store deprecation message for each argument
+            for arg in self.argstodeprecate:
+                name = arg
+                fmt = "Call to deprecated Parameter {name}."
+                if self.deprecated_args[arg]['reason']:
+                    fmt += " ({reason})"
+                if self.deprecated_args[arg]['version']:
+                    fmt += " -- Deprecated since v{version}."
+                warningargs[arg] = fmt.format(name=name, reason=self.deprecated_args[arg]['reason'] or "", version=self.deprecated_args[arg]['version'] or "")
+        else:
+            name=""
+
+        if name=="":
+            return None
+        else:
+            return warningargs
+
+    def __call__(self, wrapped):
+        """
+        Decorate your class or function.
+
+        :param wrapped: Wrapped class or function.
+
+        :return: the decorated class or function.
+        """
+        if inspect.isclass(wrapped):
+            old_new1 = wrapped.__new__
+
+            def wrapped_cls(cls, *args, **kwargs):
+                msg = self.get_deprecated_msg(wrapped=wrapped, instance=None, kwargs=kwargs)
+            
+                for key in msg.keys():
+                    message = msg[key]
+                    #create a warning for every deprecated argument
+                    if self.action:
+                        with warnings.catch_warnings():
+                            warnings.simplefilter(self.action, self.category)
+                            warnings.warn(message, category=self.category, stacklevel=_class_stacklevel)
+                    else:
+                        warnings.warn(message, category=self.category, stacklevel=_class_stacklevel)
+    
+                if old_new1 is object.__new__:
+                    return old_new1(cls)
+                # actually, we don't know the real signature of *old_new1*
+                return old_new1(cls, *args, **kwargs)
+
+            wrapped.__new__ = staticmethod(wrapped_cls)
+
+        return wrapped
+
+
+def deprecated_param(*args, **kwargs):
+    """
+    This is a decorator which can be used to mark parameters
+    as deprecated. It will result in a warning being emitted
+    when the parameter is used.
+
+    **Classic usage:**
+
+    To use this, decorate your deprecated function with **@deprecated_param** decorator:
+
+    .. code-block:: python
+
+       from deprecated import deprecated_param
+
+
+       @deprecated_param(deprecated_args={'x': {'reason': 'some reason','version': '1.0'}})
+       def some_old_function(x, y):
+           return x + y
+    """
+    if args and isinstance(args[0], string_types):
+        kwargs['reason'] = args[0]
+        args = args[1:]
+
+    if args and not callable(args[0]):
+        raise TypeError(repr(type(args[0])))
+
+    if args:
+        action = kwargs.get('action')
+        category = kwargs.get('category', DeprecationWarning)
+        adapter_cls = kwargs.pop('adapter_cls', ClassicAdapterParam)
+        adapter = adapter_cls(**kwargs)
+
+        wrapped = args[0]
+        if inspect.isclass(wrapped):
+            wrapped = adapter(wrapped)
+            return wrapped
+
+        elif inspect.isroutine(wrapped):
+
+            @wrapt.decorator(adapter=adapter)
+            def wrapper_function(wrapped_, instance_, args_, kwargs_):
+                msg = adapter.get_deprecated_msg(wrapped_, instance_, kwargs_)
+                if msg:
+                    for key in msg.keys():
+                        message = msg[key]
+                        if action:
+                            with warnings.catch_warnings():
+                                warnings.simplefilter(action, category)
+                                warnings.warn(message, category=category, stacklevel=_routine_stacklevel)
+                        else:
+                            warnings.warn(message, category=category, stacklevel=_routine_stacklevel)
+                return wrapped_(*args_, **kwargs_)
+
+            return wrapper_function(wrapped)
+
+        else:
+            raise TypeError(repr(type(wrapped)))
+
+    return functools.partial(deprecated_param, **kwargs)

--- a/deprecated/param_sphinx.py
+++ b/deprecated/param_sphinx.py
@@ -1,0 +1,224 @@
+# coding: utf-8
+"""
+Sphinx directive integration
+============================
+
+We usually need to document when a parameter is deprecated, to do this, we use `Sphinx <http://www.sphinx-doc.org>`_ directives:
+
+- We use admonitions in sphinx to render warnings for every deprecated argument just below its description in docstring.
+refer to `this <https://pradyunsg.me/furo/reference/admonitions/?highlight=warning#custom-titles>`_ link for more information.
+
+The purpose of this module is to defined decorators which adds this Sphinx directives
+to the docstring of your function and classes.
+
+Of course, the ``@deprecated_param`` decorator will emit a deprecation warning
+when the function/method is called or the class is constructed.
+"""
+import re
+import textwrap
+
+import wrapt
+
+from deprecated.param import ClassicAdapterParam
+from deprecated.param import deprecated_param as _classic_deprecated_param
+
+
+class SphinxAdapterParam(ClassicAdapterParam):
+    """
+    Sphinx adapter -- *for advanced usage only*
+
+    This adapter override the :class:`~deprecated.classic.ClassicAdapterParam`
+    in order to add the Sphinx directives to the end of the function/class docstring.
+    Such a directive is a `Paragraph-level markup <http://www.sphinx-doc.org/en/stable/markup/para.html>`_
+    - The version number is added if provided.
+    - The reason message is obviously added in the directive block if not empty.
+
+    Warnings
+    --------
+    deprecated supports docstring modification for deprecated_args only in the numpydoc format, if your documentation uses any other format, this won't work. 
+    """
+
+    def __init__(
+        self,
+        action=None,
+        category=DeprecationWarning,
+        line_length=70,
+        deprecated_args=None
+    ):
+        """
+        Construct a wrapper adapter.
+        :type  action: str
+        :param action:
+            A warning filter used to activate or not the deprecation warning.
+            Can be one of "error", "ignore", "always", "default", "module", or "once".
+            If ``None`` or empty, the the global filtering mechanism is used.
+            See: `The Warnings Filter`_ in the Python documentation.
+
+        :type  category: type
+        :param category:
+            The warning category to use for the deprecation warning.
+            By default, the category class is :class:`~DeprecationWarning`,
+            you can inherit this class to define your own deprecation warning category.
+
+        :type  line_length: int
+        :param line_length:
+            Max line length of the directive text. If non nul, a long text is wrapped in several lines.
+
+        :type deprecated_args: dict
+        :param deprecated_args:
+            Dictionary in the following format to deprecate `x` and `y`
+            deprecated_args = {'x': {'reason': 'some reason','version': '1.0'},'y': {'reason': 'another reason','version': '2.0'}}
+
+        """
+        self.line_length = line_length
+        self.deprecated_args = deprecated_args
+        super(SphinxAdapterParam, self).__init__(action=action, category=category,deprecated_args = deprecated_args)
+
+    def __call__(self, wrapped):
+        """
+        Add the Sphinx directive to your class or function.
+
+        :param wrapped: Wrapped class or function.
+
+        :return: the decorated class or function.
+        """
+        # -- build the directive division
+        docstring = textwrap.dedent(wrapped.__doc__ or "")
+        if docstring:
+        # An empty line must separate the original docstring and the directive.
+            docstring = re.sub(r"\n+$", "", docstring, flags=re.DOTALL) + "\n\n"
+        else:
+        # Avoid "Explicit markup ends without a blank line" when the decorated function has no docstring
+            docstring = "\n"
+
+        width = self.line_length - 3 if self.line_length > 3 else 2 ** 16
+        if docstring=="\n":
+            warnings.warn("Missing docstring, consider adding a numpydoc style docstring for the decorator to work (Sphinx directive won't be added)" , category=UserWarning, stacklevel=_class_stacklevel)
+        else:
+            for arg in set(self.deprecated_args.keys()):
+                #first we search for the location of the parameters section
+                search = re.search("Parameters[\s]*\n[\s]*----------", docstring)
+                if search is None:
+                    warnings.warn("Missing Parameter section, consider adding a numpydoc style parameters section in your docstring for the decorator to work (Sphinx directive won't be added)" , category=UserWarning, stacklevel=_class_stacklevel)
+                else:
+                    params_string = docstring[search.start():search.end()]
+
+                    #we store the indentation of the values 
+                    indentsize = re.search("----------", params_string).start() - re.search("Parameters[\s]*\n", params_string).end()
+                    indent = ' '*indentsize
+
+                    # we check if there is another section after parameters
+                    if re.search(f"\n{indent}-----", docstring[search.end():]) is not None:
+                        #if yes then we find the range of the parameters section
+                        params_section_end = search.end() + re.search(f"\n{indent}-----", docstring[search.end():]).start()
+                        dashes_in_next_section = docstring[params_section_end:].count('-')
+                        params_section_end = params_section_end - dashes_in_next_section
+                        params_section = docstring[search.start():params_section_end]
+                    else:
+                        #else the entire remaining docstring is in the parameters section
+                        params_section = docstring[search.start():]
+
+                    #we search for the description of the particular parameter we care about
+                    if re.search(f"\n{indent}{arg}\s*:", params_section) is not None:
+                        description_start = re.search(f"\n{indent}{arg}\s*:", params_section).end()
+                        #we check whether there are more parameters after this one, or if its the last parameter described in the secion
+                        #and store the position where we insert the warning
+
+                        if re.search(f"\n{indent}\S", params_section[description_start:]):
+                            insert_pos = re.search(f"\n{indent}\S", params_section[description_start:]).start()
+                        else:
+                            insert_pos = len(params_section[description_start:])
+                        
+                        #finally we store the warning fmt string
+                        if self.deprecated_args[arg]['version']!="":
+                            #the spaces are specifically cherrypicked for numpydoc docstrings
+                            fmt = "\n\n    .. admonition:: Deprecated\n      :class: warning\n\n      Parameter {arg} deprecated since {version}"
+                            div_lines = [fmt.format(version=self.deprecated_args[arg]['version'],arg=arg)]
+                        else:
+                            fmt = "\n\n    .. admonition:: Deprecated\n      :class: warning\n\n      Parameter {arg} deprecated"
+                            div_lines = [fmt.format(version=self.deprecated_args[arg]['version'],arg=arg)]
+                        width = 2**16
+                        reason = textwrap.dedent(self.deprecated_args[arg]['reason']).strip()
+                        reason = f'({reason})'
+                        #formatting for docstring
+                        for paragraph in reason.splitlines():
+                            if paragraph:
+                                div_lines.extend(
+                                    textwrap.fill(
+                                        paragraph,
+                                        width=width,
+                                        initial_indent='      ',
+                                        subsequent_indent='',
+                                    ).splitlines()
+                                )
+                            else:
+                                div_lines.append("")
+                        # -- append the directive division to the docstring
+                        a=''
+                        a += "".join("{}\n".format(line) for line in div_lines)
+                        a = textwrap.indent(a, indent)
+                        docstring = docstring[:search.start() + description_start+insert_pos]+"\n\n"+a+"\n\n"+docstring[search.start() + description_start+insert_pos:]
+                        docstring = re.sub(r"[\n]{3,}", "\n\n", docstring)
+                    else:
+                        warnings.warn(f"Missing description for parameter {arg}, consider adding a numpydoc style description for the decorator to work (Sphinx directive won't be added)" , category=UserWarning, stacklevel=_class_stacklevel)
+
+        wrapped.__doc__ = docstring
+        return super(SphinxAdapterParam, self).__call__(wrapped)
+
+    def get_deprecated_msg(self, wrapped, instance, kwargs):
+        """
+        Get the deprecation warning message (without Sphinx cross-referencing syntax) for the user.
+
+        :param wrapped: Wrapped class or function.
+
+        :param instance: The object to which the wrapped function was bound when it was called.
+
+        :param kwargs: The keyword arguments passed to the wrapped function.
+
+        :return: The warning message.e.
+
+        """
+        msg = super(SphinxAdapterParam, self).get_deprecated_msg(wrapped, instance, kwargs)
+        # Strip Sphinx cross reference syntax (like ":function:", ":py:func:" and ":py:meth:")
+        # Possible values are ":role:`foo`", ":domain:role:`foo`"
+        # where ``role`` and ``domain`` should match "[a-zA-Z]+"
+        
+        #remember the msg variable is a dict
+        if msg:
+            for key in msg.keys():
+                msg[key] = re.sub(r"(?: : [a-zA-Z]+ )? : [a-zA-Z]+ : (`[^`]*`)", r"\1", msg[key], flags=re.X)
+                
+        return msg
+
+def deprecated_param(deprecated_args=None, line_length=70, **kwargs):
+    """
+    This decorator can be used to insert a "deprecated" warning
+    in your function/class docstring.
+
+    :type  line_length: int
+    :param line_length:
+        Max line length of the directive text. If non nul, a long text is wrapped in several lines.
+    
+    :type deprecated_args: dict
+    :param deprecated_args: 
+        A dictionary of the form ``{'parameter_name': {'version': 'version_number', 'reason': 'reason_for_deprecation'}}``.
+
+    Keyword arguments can be:
+
+    -   "action":
+        A warning filter used to activate or not the deprecation warning.
+        Can be one of "error", "ignore", "always", "default", "module", or "once".
+        If ``None``, empty or missing, the the global filtering mechanism is used.
+
+    -   "category":
+        The warning category to use for the deprecation warning.
+        By default, the category class is :class:`~DeprecationWarning`,
+        you can inherit this class to define your own deprecation warning category.
+
+    :return: a decorator used to deprecate a function.
+    """
+    adapter_cls = kwargs.pop('adapter_cls', SphinxAdapterParam)
+    kwargs["line_length"] = line_length
+    kwargs["deprecated_args"] = deprecated_args
+
+    return _classic_deprecated_param(adapter_cls=adapter_cls, **kwargs)


### PR DESCRIPTION
I followed the contribution guide on the issue related to adding support for deprecated parameters, I had made a previous PR but I think it wasn't well formatted or according to guidelines so I made a new one. You can view the usage here.

https://gist.github.com/mjhajharia/061b5fc054ec4948fa0af3bd1083b6a2

Since chunks of the classic adapter get modified, I think for the sake of not messing up the already existing tests, it's better to create a new adapter, so I created classicadapterparam in param.py and it's sphinx equivalent in param_sphinx.py

This code itself, reformatted differently can also be seen here https://deprecat.readthedocs.io/en/latest/source/api.html#examples, it looks nice I think 

Additionally, you can see a live example of the PyMC docs generated using a PR here https://pymc--5226.org.readthedocs.build/en/5226/api/distributions/utilities.html#pymc3.distributions.Distribution

Note: 
1. we should not be using the deprecated directive for kwargs as it is only for functions or classes, so I'm making use of admonitions!
2. the sphinx directive for kwargs only works properly in numpydoc formatting of doc strings