### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,13 +33,13 @@ jobs:
         run: |
           pytest tests/
 
-  pytest-py36-py310:
+  pytest-py36-py311:
     runs-on: ${{ matrix.platform }}
 
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10-dev"  # 3.10 development branch
+  - "3.10"
+  - "3.11-dev"  # development branch
   - "pypy"
   - "pypy3"
 jobs:
@@ -18,14 +19,14 @@ jobs:
     python: "2.7"
   - arch: ppc64le
     python: "pypy"
-  - arch: ppc64le 
+  - arch: ppc64le
     python: "pypy3"
   - arch: amd64
     python: "pypy"
-    
+
 allow_failures:
     - python: "3.10-dev"
-    
+
 install:
   - pip install coveralls tox-travis
 script:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,11 @@ v1.2.14 (unreleased)
 
 Bug fix release
 
+Other
+-----
+
+- Add support for Python 3.11.
+
 
 v1.2.13 (2021-09-05)
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-target-version = ['py27', 'py34', 'py35', 'py36', 'py37', 'py38']
+target-version = ['py27', 'py34', 'py35', 'py36', 'py37', 'py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -11,19 +11,19 @@
 # - /usr/local/bin/pypy -> /opt/pypy2.7-v7.3.0-osx64/bin/pypy
 # - /usr/local/bin/pypy3 -> /opt/pypy3.6-v7.3.0-osx64/bin/pypy3
 envlist =
-    py{27,34,35,36,37,38,39,310}-wrapt{1.10,1.11,1.12,1.13}
+    py{27,34,35,36,37,38,39,310,311}-wrapt{1.10,1.11,1.12,1.13}
     pypy, pypy3
     docs
 
 [testenv]
 commands = pytest --cov-report term-missing --cov=deprecated tests/
 deps =
-    py27,py34,py35: pip >= 9.0.3, < 21
-    py27,py34: PyTest < 5
-    py35,py36,py37,py38,py39,pypy,pypy3: PyTest
-    py27,py34: PyTest-Cov < 2.6
+    py{27,34,35}: pip >= 9.0.3, < 21
+    py{27,34}: PyTest < 5
+    py{35,36,37,38,39,310,311,py,py3}: PyTest
+    py{27,34}: PyTest-Cov < 2.6
     py34: typing  # required by pytest->attrs
-    py35,py36,py37,py38,py39,py310,pypy,pypy3: PyTest-Cov
+    py{35,36,37,38,39,310,311,py,py3}: PyTest-Cov
     wrapt1.10: wrapt ~= 1.10.0
     wrapt1.11: wrapt ~= 1.11.0
     wrapt1.12: wrapt ~= 1.12.0


### PR DESCRIPTION

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with `pytest`
* add documentation to the relevant docstrings or pages
* add `versionadded` or `versionchanged` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->

Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)