### PR TITLE
fix: digest D212 and D213 docstring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,11 @@ v1.2.14 (unreleased)
 
 Bug fix release
 
+Fix
+---
+
+- Fix #60: return a correctly dedented docstring when long docstring are using the D212 or D213 format.
+
 
 v1.2.13 (2021-09-05)
 ====================

--- a/deprecated/sphinx.py
+++ b/deprecated/sphinx.py
@@ -120,7 +120,7 @@ class SphinxAdapter(ClassicAdapter):
         # -- get the docstring, normalize the trailing newlines
         # keep a consistent behaviour if the docstring starts with newline or directly on the first one
         docstring = wrapped.__doc__ or ""
-        lines = docstring.splitlines(keepends=True)
+        lines = docstring.splitlines(keepends=True) or [""]
         docstring = textwrap.dedent("".join(lines[1:])) if len(lines) > 1 else ""
         docstring = lines[0] + docstring
         if docstring:

--- a/deprecated/sphinx.py
+++ b/deprecated/sphinx.py
@@ -118,7 +118,11 @@ class SphinxAdapter(ClassicAdapter):
                 div_lines.append("")
 
         # -- get the docstring, normalize the trailing newlines
-        docstring = textwrap.dedent(wrapped.__doc__ or "")
+        # keep a consistent behaviour if the docstring starts with newline or directly on the first one
+        docstring = wrapped.__doc__ or ""
+        lines = docstring.splitlines(keepends=True)
+        docstring = textwrap.dedent("".join(lines[1:])) if len(lines) > 1 else ""
+        docstring = lines[0] + docstring
         if docstring:
             # An empty line must separate the original docstring and the directive.
             docstring = re.sub(r"\n+$", "", docstring, flags=re.DOTALL) + "\n\n"

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -23,8 +23,14 @@ import deprecated.sphinx
         :param y: number *y*
         :return: sum = *x* + *y*
         """,
+        """This function adds *x* and *y*.
+
+        :param x: number *x*
+        :param y: number *y*
+        :return: sum = *x* + *y*
+        """,
     ],
-    ids=["no_docstring", "short_docstring", "long_docstring"],
+    ids=["no_docstring", "short_docstring", "D213_long_docstring", "D212_long_docstring"],
 )
 def docstring(request):
     return request.param


### PR DESCRIPTION
Fix #60 

Parse the docstring and split the first line from the others. This ensures that whatever convention is chosen (D212 or D213) the rest of the docstring keeps the right indentation.

Commit checklist:

* [x] add tests that fail without the patch
* [x] ensure all tests pass with `pytest`
* [x] add documentation to the relevant docstrings or pages
* [x] add `versionadded` or `versionchanged` directives to relevant docstrings
* [x] add a changelog entry if this patch changes code
