### PR TITLE
fix: add `extra_stacklevel` argument to better control deprecated function call references

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Fix
 
 - Resolve Python 2.7 support issue introduced in v1.2.14 in ``sphinx.py``.
 
+- Fix #69: Add ``extra_stacklevel`` argument for interoperating with other wrapper functions (refer to #68 for a concrete use case).
+
 Other
 -----
 

--- a/deprecated/classic.py
+++ b/deprecated/classic.py
@@ -112,8 +112,12 @@ class ClassicAdapter(wrapt.AdapterFactory):
 
         :type  extra_stacklevel: int
         :param extra_stacklevel:
-            The offset to apply to the stacklevel of the emitted warning.
-            By default, no offset is applied.
+            Number of additonal stacklevels to consider instrumentation rather than user code.
+            With the default value of 0, the warning refers to where the class was instantiated
+            or the function was called.
+
+        .. versionchanged:: 1.2.15
+            Add the *extra_stacklevel* parameter.
         """
         self.reason = reason or ""
         self.version = version or ""
@@ -258,6 +262,12 @@ def deprecated(*args, **kwargs):
        def some_old_function(x, y):
            return x + y
 
+    The *extra_stacklevel* keyword argument allows you to specify additional stacklevels
+    to consider instrumentation rather than user code. With the default value of 0, the
+    warning refers to where the class was instantiated or the function was called.
+
+    .. versionchanged:: 1.2.15
+        Add the *extra_stacklevel* parameter.
     """
     if args and isinstance(args[0], string_types):
         kwargs['reason'] = args[0]

--- a/deprecated/classic.py
+++ b/deprecated/classic.py
@@ -17,7 +17,7 @@ import wrapt
 try:
     # If the C extension for wrapt was compiled and wrapt/_wrappers.pyd exists, then the
     # stack level that should be passed to warnings.warn should be 2. However, if using
-    # a pure python wrapt, a extra stacklevel is required.
+    # a pure python wrapt, an extra stacklevel is required.
     import wrapt._wrappers
 
     _routine_stacklevel = 2
@@ -101,7 +101,7 @@ class ClassicAdapter(wrapt.AdapterFactory):
         :param action:
             A warning filter used to activate or not the deprecation warning.
             Can be one of "error", "ignore", "always", "default", "module", or "once".
-            If ``None`` or empty, the the global filtering mechanism is used.
+            If ``None`` or empty, the global filtering mechanism is used.
             See: `The Warnings Filter`_ in the Python documentation.
 
         :type  category: type
@@ -112,7 +112,7 @@ class ClassicAdapter(wrapt.AdapterFactory):
 
         :type  extra_stacklevel: int
         :param extra_stacklevel:
-            Number of additonal stacklevels to consider instrumentation rather than user code.
+            Number of additional stack levels to consider instrumentation rather than user code.
             With the default value of 0, the warning refers to where the class was instantiated
             or the function was called.
 
@@ -255,7 +255,7 @@ def deprecated(*args, **kwargs):
            return x + y
 
     The *category* keyword argument allow you to specify the deprecation warning class of your choice.
-    By default, :exc:`DeprecationWarning` is used but you can choose :exc:`FutureWarning`,
+    By default, :exc:`DeprecationWarning` is used, but you can choose :exc:`FutureWarning`,
     :exc:`PendingDeprecationWarning` or a custom subclass.
 
     .. code-block:: python
@@ -269,7 +269,7 @@ def deprecated(*args, **kwargs):
 
     The *action* keyword argument allow you to locally change the warning filtering.
     *action* can be one of "error", "ignore", "always", "default", "module", or "once".
-    If ``None``, empty or missing, the the global filtering mechanism is used.
+    If ``None``, empty or missing, the global filtering mechanism is used.
     See: `The Warnings Filter`_ in the Python documentation.
 
     .. code-block:: python
@@ -281,7 +281,7 @@ def deprecated(*args, **kwargs):
        def some_old_function(x, y):
            return x + y
 
-    The *extra_stacklevel* keyword argument allows you to specify additional stacklevels
+    The *extra_stacklevel* keyword argument allows you to specify additional stack levels
     to consider instrumentation rather than user code. With the default value of 0, the
     warning refers to where the class was instantiated or the function was called.
     """

--- a/deprecated/classic.py
+++ b/deprecated/classic.py
@@ -97,14 +97,14 @@ class ClassicAdapter(wrapt.AdapterFactory):
             If you follow the `Semantic Versioning <https://semver.org/>`_,
             the version number has the format "MAJOR.MINOR.PATCH".
 
-        :type  action: str
+        :type  action: Literal["default", "error", "ignore", "always", "module", "once"]
         :param action:
             A warning filter used to activate or not the deprecation warning.
             Can be one of "error", "ignore", "always", "default", "module", or "once".
             If ``None`` or empty, the global filtering mechanism is used.
             See: `The Warnings Filter`_ in the Python documentation.
 
-        :type  category: type
+        :type  category: Type[Warning]
         :param category:
             The warning category to use for the deprecation warning.
             By default, the category class is :class:`~DeprecationWarning`,

--- a/deprecated/sphinx.py
+++ b/deprecated/sphinx.py
@@ -70,7 +70,7 @@ class SphinxAdapter(ClassicAdapter):
         :param action:
             A warning filter used to activate or not the deprecation warning.
             Can be one of "error", "ignore", "always", "default", "module", or "once".
-            If ``None`` or empty, the the global filtering mechanism is used.
+            If ``None`` or empty, the global filtering mechanism is used.
             See: `The Warnings Filter`_ in the Python documentation.
 
         :type  category: type
@@ -81,7 +81,7 @@ class SphinxAdapter(ClassicAdapter):
 
         :type  extra_stacklevel: int
         :param extra_stacklevel:
-            Number of additonal stacklevels to consider instrumentation rather than user code.
+            Number of additional stack levels to consider instrumentation rather than user code.
             With the default value of 0, the warning refers to where the class was instantiated
             or the function was called.
 
@@ -163,7 +163,7 @@ class SphinxAdapter(ClassicAdapter):
 
         """
         msg = super(SphinxAdapter, self).get_deprecated_msg(wrapped, instance)
-        # Strip Sphinx cross reference syntax (like ":function:", ":py:func:" and ":py:meth:")
+        # Strip Sphinx cross-reference syntax (like ":function:", ":py:func:" and ":py:meth:")
         # Possible values are ":role:`foo`", ":domain:role:`foo`"
         # where ``role`` and ``domain`` should match "[a-zA-Z]+"
         msg = re.sub(r"(?: : [a-zA-Z]+ )? : [a-zA-Z]+ : (`[^`]*`)", r"\1", msg, flags=re.X)
@@ -173,7 +173,7 @@ class SphinxAdapter(ClassicAdapter):
 def versionadded(reason="", version="", line_length=70):
     """
     This decorator can be used to insert a "versionadded" directive
-    in your function/class docstring in order to documents the
+    in your function/class docstring in order to document the
     version of the project which adds this new functionality in your library.
 
     :param str reason:
@@ -203,7 +203,7 @@ def versionadded(reason="", version="", line_length=70):
 def versionchanged(reason="", version="", line_length=70):
     """
     This decorator can be used to insert a "versionchanged" directive
-    in your function/class docstring in order to documents the
+    in your function/class docstring in order to document the
     version of the project which modifies this functionality in your library.
 
     :param str reason:
@@ -232,7 +232,7 @@ def versionchanged(reason="", version="", line_length=70):
 def deprecated(reason="", version="", line_length=70, **kwargs):
     """
     This decorator can be used to insert a "deprecated" directive
-    in your function/class docstring in order to documents the
+    in your function/class docstring in order to document the
     version of the project which deprecates this functionality in your library.
 
     :param str reason:
@@ -252,15 +252,15 @@ def deprecated(reason="", version="", line_length=70, **kwargs):
     -   "action":
         A warning filter used to activate or not the deprecation warning.
         Can be one of "error", "ignore", "always", "default", "module", or "once".
-        If ``None``, empty or missing, the the global filtering mechanism is used.
+        If ``None``, empty or missing, the global filtering mechanism is used.
 
     -   "category":
         The warning category to use for the deprecation warning.
         By default, the category class is :class:`~DeprecationWarning`,
         you can inherit this class to define your own deprecation warning category.
-    
+
     -   "extra_stacklevel":
-        Number of additional stacklevels to consider instrumentation rather than user code.
+        Number of additional stack levels to consider instrumentation rather than user code.
         With the default value of 0, the warning refers to where the class was instantiated
         or the function was called.
 

--- a/deprecated/sphinx.py
+++ b/deprecated/sphinx.py
@@ -22,8 +22,6 @@ when the function/method is called or the class is constructed.
 import re
 import textwrap
 
-import wrapt
-
 from deprecated.classic import ClassicAdapter
 from deprecated.classic import deprecated as _classic_deprecated
 
@@ -83,12 +81,16 @@ class SphinxAdapter(ClassicAdapter):
 
         :type  extra_stacklevel: int
         :param extra_stacklevel:
-            The offset to apply to the stacklevel of the emitted warning.
-            By default, no offset is applied.
+            Number of additonal stacklevels to consider instrumentation rather than user code.
+            With the default value of 0, the warning refers to where the class was instantiated
+            or the function was called.
 
         :type  line_length: int
         :param line_length:
             Max line length of the directive text. If non nul, a long text is wrapped in several lines.
+
+        .. versionchanged:: 1.2.15
+            Add the *extra_stacklevel* parameter.
         """
         if not version:
             # https://github.com/tantale/deprecated/issues/40
@@ -258,14 +260,18 @@ def deprecated(reason="", version="", line_length=70, **kwargs):
         you can inherit this class to define your own deprecation warning category.
     
     -   "extra_stacklevel":
-        The offset to apply to the stacklevel of the emitted warning.
-        By default, no offset is applied.
+        Number of additional stacklevels to consider instrumentation rather than user code.
+        With the default value of 0, the warning refers to where the class was instantiated
+        or the function was called.
 
 
     :return: a decorator used to deprecate a function.
 
     .. versionchanged:: 1.2.13
        Change the signature of the decorator to reflect the valid use cases.
+
+    .. versionchanged:: 1.2.15
+        Add the *extra_stacklevel* parameter.
     """
     directive = kwargs.pop('directive', 'deprecated')
     adapter_cls = kwargs.pop('adapter_cls', SphinxAdapter)

--- a/deprecated/sphinx.py
+++ b/deprecated/sphinx.py
@@ -66,14 +66,14 @@ class SphinxAdapter(ClassicAdapter):
             If you follow the `Semantic Versioning <https://semver.org/>`_,
             the version number has the format "MAJOR.MINOR.PATCH".
 
-        :type  action: str
+        :type  action: Literal["default", "error", "ignore", "always", "module", "once"]
         :param action:
             A warning filter used to activate or not the deprecation warning.
             Can be one of "error", "ignore", "always", "default", "module", or "once".
             If ``None`` or empty, the global filtering mechanism is used.
             See: `The Warnings Filter`_ in the Python documentation.
 
-        :type  category: type
+        :type  category: Type[Warning]
         :param category:
             The warning category to use for the deprecation warning.
             By default, the category class is :class:`~DeprecationWarning`,

--- a/deprecated/sphinx.py
+++ b/deprecated/sphinx.py
@@ -48,6 +48,7 @@ class SphinxAdapter(ClassicAdapter):
         version="",
         action=None,
         category=DeprecationWarning,
+        extra_stacklevel=0,
         line_length=70,
     ):
         """
@@ -80,6 +81,11 @@ class SphinxAdapter(ClassicAdapter):
             By default, the category class is :class:`~DeprecationWarning`,
             you can inherit this class to define your own deprecation warning category.
 
+        :type  extra_stacklevel: int
+        :param extra_stacklevel:
+            The offset to apply to the stacklevel of the emitted warning.
+            By default, no offset is applied.
+
         :type  line_length: int
         :param line_length:
             Max line length of the directive text. If non nul, a long text is wrapped in several lines.
@@ -89,7 +95,9 @@ class SphinxAdapter(ClassicAdapter):
             raise ValueError("'version' argument is required in Sphinx directives")
         self.directive = directive
         self.line_length = line_length
-        super(SphinxAdapter, self).__init__(reason=reason, version=version, action=action, category=category)
+        super(SphinxAdapter, self).__init__(
+            reason=reason, version=version, action=action, category=category, extra_stacklevel=extra_stacklevel
+        )
 
     def __call__(self, wrapped):
         """
@@ -102,7 +110,7 @@ class SphinxAdapter(ClassicAdapter):
         # -- build the directive division
         fmt = ".. {directive}:: {version}" if self.version else ".. {directive}::"
         div_lines = [fmt.format(directive=self.directive, version=self.version)]
-        width = self.line_length - 3 if self.line_length > 3 else 2 ** 16
+        width = self.line_length - 3 if self.line_length > 3 else 2**16
         reason = textwrap.dedent(self.reason).strip()
         for paragraph in reason.splitlines():
             if paragraph:
@@ -248,6 +256,11 @@ def deprecated(reason="", version="", line_length=70, **kwargs):
         The warning category to use for the deprecation warning.
         By default, the category class is :class:`~DeprecationWarning`,
         you can inherit this class to define your own deprecation warning category.
+    
+    -   "extra_stacklevel":
+        The offset to apply to the stacklevel of the emitted warning.
+        By default, no offset is applied.
+
 
     :return: a decorator used to deprecate a function.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -242,3 +242,28 @@ function will raise an exception because the *action* is set to "error".
      File "path/to/deprecated/classic.py", line 274, in wrapper_function
        warnings.warn(msg, category=category, stacklevel=_stacklevel)
    DeprecationWarning: Call to deprecated function (or staticmethod) foo. (do not call it)
+
+
+Modifying the deprecated code reference
+---------------------------------------
+
+By default, when a deprecated function or class is called, the warning message indicates the location of the caller.
+
+The ``extra_stacklevel`` parameter allows customizing the stack level reference in the deprecation warning message.
+
+This parameter is particularly useful in scenarios where you have a factory or utility function that creates deprecated
+objects or performs deprecated operations. By specifying an ``extra_stacklevel`` value, you can control the stack level
+at which the deprecation warning is emitted, making it appear as if the calling function is the deprecated one,
+rather than the actual deprecated entity.
+
+For example, if you have a factory function ``create_object()`` that creates deprecated objects, you can use
+the ``extra_stacklevel`` parameter to emit the deprecation warning at the calling location. This provides clearer and
+more actionable deprecation messages, allowing developers to identify and update the code that invokes the deprecated
+functionality.
+
+For instance:
+
+.. literalinclude:: tutorial/warning_ctrl/extra_stacklevel_demo.py
+
+Please note that the ``extra_stacklevel`` value should be an integer indicating the number of stack levels to skip
+when emitting the deprecation warning.

--- a/docs/source/tutorial/warning_ctrl/extra_stacklevel_demo.py
+++ b/docs/source/tutorial/warning_ctrl/extra_stacklevel_demo.py
@@ -1,0 +1,24 @@
+import warnings
+
+from deprecated import deprecated
+
+
+@deprecated(version='1.0', extra_stacklevel=1)
+class MyObject(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return "object: {name}".format(name=self.name)
+
+
+def create_object(name):
+    return MyObject(name)
+
+
+if __name__ == '__main__':
+    warnings.filterwarnings("default", category=DeprecationWarning)
+    # warn here:
+    print(create_object("orange"))
+    # and also here:
+    print(create_object("banane"))

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -263,3 +263,18 @@ def test_respect_global_filter():
         fun()
         fun()
     assert len(warns) == 1
+
+
+def test_extra_stacklevel():
+    @deprecated.classic.deprecated(version='1.2.1', reason="deprecated function", extra_stacklevel=1)
+    def inner():
+        pass
+        
+    def outer():
+        inner()
+
+    warnings.simplefilter("default", category=DeprecationWarning)
+    with warnings.catch_warnings(record=True) as warns:
+        outer()
+        outer()
+    assert len(warns) == 2

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -11,6 +11,10 @@ class MyDeprecationWarning(DeprecationWarning):
     pass
 
 
+class WrongStackLevelWarning(DeprecationWarning):
+    pass
+
+
 _PARAMS = [
     None,
     ((), {}),
@@ -19,6 +23,7 @@ _PARAMS = [
     ((), {'version': '1.2.3'}),
     ((), {'action': 'once'}),
     ((), {'category': MyDeprecationWarning}),
+    ((), {'extra_stacklevel': 1, 'category': WrongStackLevelWarning}),
 ]
 
 
@@ -136,7 +141,7 @@ def test_classic_deprecated_function__warns(classic_deprecated_function):
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated function (or staticmethod)" in str(warn.message)
-    assert warn.filename == __file__, 'Incorrect warning stackLevel'
+    assert warn.filename == __file__ or warn.category is WrongStackLevelWarning, 'Incorrect warning stackLevel'
 
 
 # noinspection PyShadowingNames
@@ -148,7 +153,7 @@ def test_classic_deprecated_class__warns(classic_deprecated_class):
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated class" in str(warn.message)
-    assert warn.filename == __file__, 'Incorrect warning stackLevel'
+    assert warn.filename == __file__ or warn.category is WrongStackLevelWarning, 'Incorrect warning stackLevel'
 
 
 # noinspection PyShadowingNames
@@ -161,7 +166,7 @@ def test_classic_deprecated_method__warns(classic_deprecated_method):
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated method" in str(warn.message)
-    assert warn.filename == __file__, 'Incorrect warning stackLevel'
+    assert warn.filename == __file__ or warn.category is WrongStackLevelWarning, 'Incorrect warning stackLevel'
 
 
 # noinspection PyShadowingNames
@@ -173,7 +178,7 @@ def test_classic_deprecated_static_method__warns(classic_deprecated_static_metho
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
     assert "deprecated function (or staticmethod)" in str(warn.message)
-    assert warn.filename == __file__, 'Incorrect warning stackLevel'
+    assert warn.filename == __file__ or warn.category is WrongStackLevelWarning, 'Incorrect warning stackLevel'
 
 
 # noinspection PyShadowingNames
@@ -189,7 +194,7 @@ def test_classic_deprecated_class_method__warns(classic_deprecated_class_method)
         assert "deprecated class method" in str(warn.message)
     else:
         assert "deprecated function (or staticmethod)" in str(warn.message)
-    assert warn.filename == __file__, 'Incorrect warning stackLevel'
+    assert warn.filename == __file__ or warn.category is WrongStackLevelWarning, 'Incorrect warning stackLevel'
 
 
 def test_should_raise_type_error():


### PR DESCRIPTION
Fixes #68 .

Adds an argument `extra_stacklevel` to the classic and sphinx `deprecated` functions (and adapters) to modify the `stacklevel` which the warnings refer to.

Documentation of the patch is still weak and an explicit functional test needs to be added.

- [x] add tests that fail without the patch
- [x] ensure all tests pass with `pytest`
- [x] add documentation to the relevant docstrings or pages
- [x] add `versionadded` or `versionchanged` directives to relevant docstrings
- [x] add a changelog entry if this patch changes code

