### PR TITLE
from python<=3.7 support

### DIFF
--- a/deprecated/__init__.py
+++ b/deprecated/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Deprecated Library
 ==================
@@ -8,7 +7,7 @@ Python ``@deprecated`` decorator to deprecate old python classes, functions or m
 """
 
 __version__ = "1.2.14"
-__author__ = u"Laurent LAPORTE <tantale.solutions@gmail.com>"
+__author__ = "Laurent LAPORTE <tantale.solutions@gmail.com>"
 __date__ = "2023-05-27"
 __credits__ = "(c) Laurent LAPORTE"
 

--- a/deprecated/classic.py
+++ b/deprecated/classic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Classic deprecation warning
 ===========================
@@ -29,7 +28,7 @@ except ImportError:
     else:
         _class_stacklevel = 3
 
-string_types = (type(b''), type(u''))
+string_types = (bytes, str)
 
 
 class ClassicAdapter(wrapt.AdapterFactory):
@@ -124,7 +123,7 @@ class ClassicAdapter(wrapt.AdapterFactory):
         self.action = action
         self.category = category
         self.extra_stacklevel = extra_stacklevel
-        super(ClassicAdapter, self).__init__()
+        super().__init__()
 
     def get_deprecated_msg(self, wrapped, instance):
         """

--- a/deprecated/sphinx.py
+++ b/deprecated/sphinx.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Sphinx directive integration
 ============================
@@ -97,7 +96,7 @@ class SphinxAdapter(ClassicAdapter):
             raise ValueError("'version' argument is required in Sphinx directives")
         self.directive = directive
         self.line_length = line_length
-        super(SphinxAdapter, self).__init__(
+        super().__init__(
             reason=reason, version=version, action=action, category=category, extra_stacklevel=extra_stacklevel
         )
 
@@ -141,12 +140,12 @@ class SphinxAdapter(ClassicAdapter):
             docstring = "\n"
 
         # -- append the directive division to the docstring
-        docstring += "".join("{}\n".format(line) for line in div_lines)
+        docstring += "".join(f"{line}\n" for line in div_lines)
 
         wrapped.__doc__ = docstring
         if self.directive in {"versionadded", "versionchanged"}:
             return wrapped
-        return super(SphinxAdapter, self).__call__(wrapped)
+        return super().__call__(wrapped)
 
     def get_deprecated_msg(self, wrapped, instance):
         """
@@ -162,7 +161,7 @@ class SphinxAdapter(ClassicAdapter):
            Strip Sphinx cross-referencing syntax from warning message.
 
         """
-        msg = super(SphinxAdapter, self).get_deprecated_msg(wrapped, instance)
+        msg = super().get_deprecated_msg(wrapped, instance)
         # Strip Sphinx cross-reference syntax (like ":function:", ":py:func:" and ":py:meth:")
         # Possible values are ":role:`foo`", ":domain:role:`foo`"
         # where ``role`` and ``domain`` should match "[a-zA-Z]+"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # Deprecated Library Documentation build configuration file, created by
 # sphinx-quickstart on Wed Jul 19 22:23:11 2017.

--- a/docs/source/sphinx/sphinx_demo.py
+++ b/docs/source/sphinx/sphinx_demo.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from deprecated.sphinx import deprecated
 from deprecated.sphinx import versionadded
 from deprecated.sphinx import versionchanged

--- a/docs/source/tutorial/v0/liberty.py
+++ b/docs/source/tutorial/v0/liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """ Liberty library is free """
 
 import pprint

--- a/docs/source/tutorial/v1/liberty.py
+++ b/docs/source/tutorial/v1/liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """ Liberty library is free """
 
 import pprint

--- a/docs/source/tutorial/v1/using_liberty.py
+++ b/docs/source/tutorial/v1/using_liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import liberty
 
 liberty.print_value("hello")

--- a/docs/source/tutorial/v2/liberty.py
+++ b/docs/source/tutorial/v2/liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """ Liberty library is free """
 
 import pprint

--- a/docs/source/tutorial/v2/using_liberty.py
+++ b/docs/source/tutorial/v2/using_liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import liberty
 
 liberty.print_value("hello")

--- a/docs/source/tutorial/v3/liberty.py
+++ b/docs/source/tutorial/v3/liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """ Liberty library is free """
 
 import pprint
@@ -6,7 +5,7 @@ import pprint
 from deprecated import deprecated
 
 
-class Liberty(object):
+class Liberty:
     def __init__(self, value):
         self.value = value
 

--- a/docs/source/tutorial/v3/using_liberty.py
+++ b/docs/source/tutorial/v3/using_liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import liberty
 
 obj = liberty.Liberty("Greeting")

--- a/docs/source/tutorial/v4/liberty.py
+++ b/docs/source/tutorial/v4/liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """ Liberty library is free """
 
 import pprint
@@ -7,7 +6,7 @@ from deprecated import deprecated
 
 
 @deprecated("This class is not perfect")
-class Liberty(object):
+class Liberty:
     def __init__(self, value):
         self.value = value
 

--- a/docs/source/tutorial/v4/using_liberty.py
+++ b/docs/source/tutorial/v4/using_liberty.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import liberty
 
 obj = liberty.Liberty("Salutation")

--- a/docs/source/tutorial/warning_ctrl/extra_stacklevel_demo.py
+++ b/docs/source/tutorial/warning_ctrl/extra_stacklevel_demo.py
@@ -4,12 +4,12 @@ from deprecated import deprecated
 
 
 @deprecated(version='1.0', extra_stacklevel=1)
-class MyObject(object):
+class MyObject:
     def __init__(self, name):
         self.name = name
 
     def __str__(self):
-        return "object: {name}".format(name=self.name)
+        return f"object: {self.name}"
 
 
 def create_object(name):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-#  -*- coding: utf-8 -*-
-u"""
+"""
 Deprecated Library
 ------------------
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import pkg_resources
 
 import deprecated

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import inspect
 import sys
 import warnings
@@ -52,7 +51,7 @@ def classic_deprecated_class(request):
     if request.param is None:
 
         @deprecated.classic.deprecated
-        class Foo2(object):
+        class Foo2:
             pass
 
         return Foo2
@@ -60,7 +59,7 @@ def classic_deprecated_class(request):
         args, kwargs = request.param
 
         @deprecated.classic.deprecated(*args, **kwargs)
-        class Foo2(object):
+        class Foo2:
             pass
 
         return Foo2
@@ -70,7 +69,7 @@ def classic_deprecated_class(request):
 def classic_deprecated_method(request):
     if request.param is None:
 
-        class Foo3(object):
+        class Foo3:
             @deprecated.classic.deprecated
             def foo3(self):
                 pass
@@ -79,7 +78,7 @@ def classic_deprecated_method(request):
     else:
         args, kwargs = request.param
 
-        class Foo3(object):
+        class Foo3:
             @deprecated.classic.deprecated(*args, **kwargs)
             def foo3(self):
                 pass
@@ -91,7 +90,7 @@ def classic_deprecated_method(request):
 def classic_deprecated_static_method(request):
     if request.param is None:
 
-        class Foo4(object):
+        class Foo4:
             @staticmethod
             @deprecated.classic.deprecated
             def foo4():
@@ -101,7 +100,7 @@ def classic_deprecated_static_method(request):
     else:
         args, kwargs = request.param
 
-        class Foo4(object):
+        class Foo4:
             @staticmethod
             @deprecated.classic.deprecated(*args, **kwargs)
             def foo4():
@@ -114,7 +113,7 @@ def classic_deprecated_static_method(request):
 def classic_deprecated_class_method(request):
     if request.param is None:
 
-        class Foo5(object):
+        class Foo5:
             @classmethod
             @deprecated.classic.deprecated
             def foo5(cls):
@@ -124,7 +123,7 @@ def classic_deprecated_class_method(request):
     else:
         args, kwargs = request.param
 
-        class Foo5(object):
+        class Foo5:
             @classmethod
             @deprecated.classic.deprecated(*args, **kwargs)
             def foo5(cls):

--- a/tests/test_deprecated_class.py
+++ b/tests/test_deprecated_class.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-from __future__ import print_function
-
 import inspect
 import io
 import warnings
@@ -14,10 +11,10 @@ def test_simple_class_deprecation():
 
     # To deprecate a class, it is better to emit a message when ``__new__`` is called.
     # The simplest way is to override the ``__new__``method.
-    class MyBaseClass(object):
+    class MyBaseClass:
         def __new__(cls, *args, **kwargs):
-            print(u"I am deprecated!", file=stream)
-            return super(MyBaseClass, cls).__new__(cls, *args, **kwargs)
+            print("I am deprecated!", file=stream)
+            return super().__new__(cls, *args, **kwargs)
 
     # Of course, the subclass will be deprecated too
     class MySubClass(MyBaseClass):
@@ -26,14 +23,14 @@ def test_simple_class_deprecation():
     obj = MySubClass()
     assert isinstance(obj, MyBaseClass)
     assert inspect.isclass(MyBaseClass)
-    assert stream.getvalue().strip() == u"I am deprecated!"
+    assert stream.getvalue().strip() == "I am deprecated!"
 
 
 def test_class_deprecation_using_wrapper():
     # stream is used to store the deprecation message for testing
     stream = io.StringIO()
 
-    class MyBaseClass(object):
+    class MyBaseClass:
         pass
 
     # To deprecated the class, we use a wrapper function which emits
@@ -42,7 +39,7 @@ def test_class_deprecation_using_wrapper():
     original_new = MyBaseClass.__new__
 
     def wrapped_new(unused, *args, **kwargs):
-        print(u"I am deprecated!", file=stream)
+        print("I am deprecated!", file=stream)
         return original_new(*args, **kwargs)
 
     # Like ``__new__``, this wrapper is a class method.
@@ -55,7 +52,7 @@ def test_class_deprecation_using_wrapper():
     obj = MySubClass()
     assert isinstance(obj, MyBaseClass)
     assert inspect.isclass(MyBaseClass)
-    assert stream.getvalue().strip() == u"I am deprecated!"
+    assert stream.getvalue().strip() == "I am deprecated!"
 
 
 def test_class_deprecation_using_a_simple_decorator():
@@ -69,14 +66,14 @@ def test_class_deprecation_using_a_simple_decorator():
         old_new = wrapped_cls.__new__
 
         def wrapped_new(unused, *args, **kwargs):
-            print(u"I am deprecated!", file=stream)
+            print("I am deprecated!", file=stream)
             return old_new(*args, **kwargs)
 
         wrapped_cls.__new__ = classmethod(wrapped_new)
         return wrapped_cls
 
     @simple_decorator
-    class MyBaseClass(object):
+    class MyBaseClass:
         pass
 
     class MySubClass(MyBaseClass):
@@ -85,12 +82,12 @@ def test_class_deprecation_using_a_simple_decorator():
     obj = MySubClass()
     assert isinstance(obj, MyBaseClass)
     assert inspect.isclass(MyBaseClass)
-    assert stream.getvalue().strip() == u"I am deprecated!"
+    assert stream.getvalue().strip() == "I am deprecated!"
 
 
 def test_class_deprecation_using_deprecated_decorator():
     @deprecated.classic.deprecated
-    class MyBaseClass(object):
+    class MyBaseClass:
         pass
 
     class MySubClass(MyBaseClass):
@@ -108,7 +105,7 @@ def test_class_deprecation_using_deprecated_decorator():
 
 def test_class_respect_global_filter():
     @deprecated.classic.deprecated
-    class MyBaseClass(object):
+    class MyBaseClass:
         pass
 
     with warnings.catch_warnings(record=True) as warns:
@@ -121,7 +118,7 @@ def test_class_respect_global_filter():
 
 def test_subclass_deprecation_using_deprecated_decorator():
     @deprecated.classic.deprecated
-    class MyBaseClass(object):
+    class MyBaseClass:
         pass
 
     @deprecated.classic.deprecated
@@ -140,9 +137,9 @@ def test_subclass_deprecation_using_deprecated_decorator():
 
 def test_simple_class_deprecation_with_args():
     @deprecated.classic.deprecated('kwargs class')
-    class MyClass(object):
+    class MyClass:
         def __init__(self, arg):
-            super(MyClass, self).__init__()
+            super().__init__()
             self.args = arg
 
     MyClass(5)

--- a/tests/test_deprecated_metaclass.py
+++ b/tests/test_deprecated_metaclass.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import warnings
 
 import deprecated.classic
@@ -23,7 +22,7 @@ def with_metaclass(meta, *bases):
 
 def test_with_init():
     @deprecated.classic.deprecated
-    class MyClass(object):
+    class MyClass:
         def __init__(self, a, b=5):
             self.a = a
             self.b = b
@@ -40,9 +39,9 @@ def test_with_init():
 
 def test_with_new():
     @deprecated.classic.deprecated
-    class MyClass(object):
+    class MyClass:
         def __new__(cls, a, b=5):
-            obj = super(MyClass, cls).__new__(cls)
+            obj = super().__new__(cls)
             obj.c = 3.14
             return obj
 
@@ -64,7 +63,7 @@ def test_with_new():
 def test_with_metaclass():
     class Meta(type):
         def __call__(cls, *args, **kwargs):
-            obj = super(Meta, cls).__call__(*args, **kwargs)
+            obj = super().__call__(*args, **kwargs)
             obj.c = 3.14
             return obj
 
@@ -91,7 +90,7 @@ def test_with_singleton_metaclass():
 
         def __call__(cls, *args, **kwargs):
             if cls not in cls._instances:
-                cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+                cls._instances[cls] = super().__call__(*args, **kwargs)
             return cls._instances[cls]
 
     @deprecated.classic.deprecated

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-from __future__ import print_function
-
 import re
 import sys
 import textwrap
@@ -136,7 +133,7 @@ def test_has_sphinx_docstring(docstring, directive, reason, version, expected):
 )
 def test_cls_has_sphinx_docstring(docstring, directive, reason, version, expected):
     # The class:
-    class Foo(object):
+    class Foo:
         pass
 
     # with docstring:
@@ -200,7 +197,7 @@ def sphinx_deprecated_class(request):
     kwargs = request.param
 
     @deprecated.sphinx.deprecated(**kwargs)
-    class Foo2(object):
+    class Foo2:
         pass
 
     return Foo2
@@ -210,7 +207,7 @@ def sphinx_deprecated_class(request):
 def sphinx_deprecated_method(request):
     kwargs = request.param
 
-    class Foo3(object):
+    class Foo3:
         @deprecated.sphinx.deprecated(**kwargs)
         def foo3(self):
             pass
@@ -222,7 +219,7 @@ def sphinx_deprecated_method(request):
 def sphinx_deprecated_static_method(request):
     kwargs = request.param
 
-    class Foo4(object):
+    class Foo4:
         @staticmethod
         @deprecated.sphinx.deprecated(**kwargs)
         def foo4():
@@ -235,7 +232,7 @@ def sphinx_deprecated_static_method(request):
 def sphinx_deprecated_class_method(request):
     kwargs = request.param
 
-    class Foo5(object):
+    class Foo5:
         @classmethod
         @deprecated.sphinx.deprecated(**kwargs)
         def foo5(cls):

--- a/tests/test_sphinx_adapter.py
+++ b/tests/test_sphinx_adapter.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import textwrap
 
 import pytest

--- a/tests/test_sphinx_class.py
+++ b/tests/test_sphinx_class.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-from __future__ import print_function
-
 import inspect
 import io
 import sys
@@ -22,14 +19,14 @@ def test_class_deprecation_using_a_simple_decorator():
         old_new = wrapped_cls.__new__
 
         def wrapped_new(unused, *args, **kwargs):
-            print(u"I am deprecated!", file=stream)
+            print("I am deprecated!", file=stream)
             return old_new(*args, **kwargs)
 
         wrapped_cls.__new__ = classmethod(wrapped_new)
         return wrapped_cls
 
     @simple_decorator
-    class MyBaseClass(object):
+    class MyBaseClass:
         pass
 
     class MySubClass(MyBaseClass):
@@ -38,7 +35,7 @@ def test_class_deprecation_using_a_simple_decorator():
     obj = MySubClass()
     assert isinstance(obj, MyBaseClass)
     assert inspect.isclass(MyBaseClass)
-    assert stream.getvalue().strip() == u"I am deprecated!"
+    assert stream.getvalue().strip() == "I am deprecated!"
 
 
 @pytest.mark.skipif(
@@ -46,7 +43,7 @@ def test_class_deprecation_using_a_simple_decorator():
 )
 def test_class_deprecation_using_deprecated_decorator():
     @deprecated.sphinx.deprecated(version="7.8.9")
-    class MyBaseClass(object):
+    class MyBaseClass:
         pass
 
     class MySubClass(MyBaseClass):
@@ -67,7 +64,7 @@ def test_class_deprecation_using_deprecated_decorator():
 )
 def test_subclass_deprecation_using_deprecated_decorator():
     @deprecated.sphinx.deprecated(version="7.8.9")
-    class MyBaseClass(object):
+    class MyBaseClass:
         pass
 
     @deprecated.sphinx.deprecated(version="7.8.9")

--- a/tests/test_sphinx_metaclass.py
+++ b/tests/test_sphinx_metaclass.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import warnings
 
 import deprecated.sphinx
@@ -23,7 +22,7 @@ def with_metaclass(meta, *bases):
 
 def test_with_init():
     @deprecated.classic.deprecated
-    class MyClass(object):
+    class MyClass:
         def __init__(self, a, b=5):
             self.a = a
             self.b = b
@@ -40,9 +39,9 @@ def test_with_init():
 
 def test_with_new():
     @deprecated.classic.deprecated
-    class MyClass(object):
+    class MyClass:
         def __new__(cls, a, b=5):
-            obj = super(MyClass, cls).__new__(cls)
+            obj = super().__new__(cls)
             obj.c = 3.14
             return obj
 
@@ -64,7 +63,7 @@ def test_with_new():
 def test_with_metaclass():
     class Meta(type):
         def __call__(cls, *args, **kwargs):
-            obj = super(Meta, cls).__call__(*args, **kwargs)
+            obj = super().__call__(*args, **kwargs)
             obj.c = 3.14
             return obj
 
@@ -91,7 +90,7 @@ def test_with_singleton_metaclass():
 
         def __call__(cls, *args, **kwargs):
             if cls not in cls._instances:
-                cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+                cls._instances[cls] = super().__call__(*args, **kwargs)
             return cls._instances[cls]
 
     @deprecated.classic.deprecated


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 support has been EOSed 27 Jun 2023.
Pass all code over `pyupgrade --py38`.
