### PR TITLE
Update class method deprecation warnings for Python 3.13

### DIFF
--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -191,7 +191,7 @@ def test_classic_deprecated_class_method__warns(classic_deprecated_class_method)
     assert len(warns) == 1
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
-    if sys.version_info >= (3, 9):
+    if (3, 9) <= sys.version_info < (3, 13):
         assert "deprecated class method" in str(warn.message)
     else:
         assert "deprecated function (or staticmethod)" in str(warn.message)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -301,7 +301,7 @@ def test_sphinx_deprecated_class_method__warns(sphinx_deprecated_class_method):
     assert len(warns) == 1
     warn = warns[0]
     assert issubclass(warn.category, DeprecationWarning)
-    if sys.version_info >= (3, 9):
+    if (3, 9) <= sys.version_info < (3, 13):
         assert "deprecated class method" in str(warn.message)
     else:
         assert "deprecated function (or staticmethod)" in str(warn.message)


### PR DESCRIPTION
Update the version range for modified deprecation warnings that was introduced in efb3e60623e1dda88c2725a93223d290924e8666, since Python 3.13 reverted the change originally introduced in 3.9 and is back to the old messages.  This fixes tests with Python 3.13.

See also https://github.com/GrahamDumpleton/wrapt/pull/260.