### PR TITLE
Replace pkg_resources version parsing in tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest setuptools
+          python -m pip install packaging pytest setuptools
           python -m pip install -e .
       - name: Test with pytest
         run: |

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,7 @@ setup(
             "tox",
             "PyTest",
             "PyTest-Cov",
+            "packaging",
             "bump2version < 1",
             "setuptools; python_version>='3.12'",
         ]

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-import pkg_resources
+import packaging.version
 
 import deprecated
 
@@ -13,7 +13,7 @@ def test_deprecated_has_docstring():
 def test_deprecated_has_version():
     # The deprecated package must have a valid version number
     assert deprecated.__version__ is not None
-    version = pkg_resources.parse_version(deprecated.__version__)
+    version = packaging.version.parse(deprecated.__version__)
 
     # .. note::
     #

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ envlist =
 [testenv]
 commands = pytest tests/
 deps =
+    packaging
     py{37,38,39,310,311,312,313,314,py3}: PyTest
     wrapt1.10: wrapt ~= 1.10.0
     wrapt1.11: wrapt ~= 1.11.0
@@ -40,6 +41,7 @@ commands =
     pytest --cov-report=term-missing --cov=deprecated --cov-report=html tests/
 deps =
     coverage
+    packaging
     pytest
     pytest-cov
     setuptools; python_version>="3.12"


### PR DESCRIPTION
Fixes #98.

Summary:
- replace `pkg_resources.parse_version()` in the version test with `packaging.version.parse()`
- add `packaging` to the tox test dependencies and development extra
- install `packaging` in the GitHub Actions test workflow before running pytest

Validation:
- Not run locally.